### PR TITLE
Fix snyk container run on a Dockerfile with a custom name

### DIFF
--- a/hooks/snyk-container.sh
+++ b/hooks/snyk-container.sh
@@ -54,7 +54,7 @@ for file_path in "${dockerfiles[@]}"; do
     echo ""
   fi
   printf "%s Building %s from %s\n\n" "$prefix" "$image" "$file_path"
-  container_build "$image" "$(echo "$file_path" | rev | cut -d'/' -f2- | rev)"
+  container_build "$image" "$file_path"
   printf "\n%s Testing %s\n" "$prefix" "$image"
   snyk container test "$image" "--file=$file_path" "${snyk_args[*]}"
   printf "\n%s Removing %s" "$prefix" "$image"

--- a/hooks/snyk-container.sh
+++ b/hooks/snyk-container.sh
@@ -38,10 +38,10 @@ snyk_args=()
 dockerfiles=()
 for arg in "$@"; do
   echo ">> $arg"
-  if [[ $arg == *Dockerfile ]]; then
-    dockerfiles+=("$arg")
-  else
+  if [ "${arg#-}" != "$arg" ]; then
     snyk_args+=("$arg")
+  else
+    dockerfiles+=("$arg")
   fi
 done
 

--- a/hooks/snyk-container.sh
+++ b/hooks/snyk-container.sh
@@ -13,9 +13,9 @@ container_build() {
   tag="$1"
   path="$2"
   if command -v docker &> /dev/null; then
-    docker build -t "$tag" "$path"
+    docker build -t "$tag" -f "$path" .
   elif command -v podman &> /dev/null; then
-    podman build -t "$tag" "$path"
+    podman build -t "$tag" -f "$path" .
   else
     echo "$prefix docker or podman are not found. Please install one of these tools and try again"
     exit 1

--- a/hooks/snyk-container.sh
+++ b/hooks/snyk-container.sh
@@ -37,7 +37,6 @@ container_rmi() {
 snyk_args=()
 dockerfiles=()
 for arg in "$@"; do
-  echo ">> $arg"
   if [ "${arg#-}" != "$arg" ]; then
     snyk_args+=("$arg")
   else

--- a/hooks/snyk-container.sh
+++ b/hooks/snyk-container.sh
@@ -37,6 +37,7 @@ container_rmi() {
 snyk_args=()
 dockerfiles=()
 for arg in "$@"; do
+  echo ">> $arg"
   if [[ $arg == *Dockerfile ]]; then
     dockerfiles+=("$arg")
   else


### PR DESCRIPTION
### Description

There was an issue when user tries to run `snyk-container` hook with a dockerfile with a custom name, e.g. `Containerfile` or `arm64.dockerfile`, etc.